### PR TITLE
fix: style preview for editor #49

### DIFF
--- a/styles/s1-crayola.json
+++ b/styles/s1-crayola.json
@@ -16,9 +16,9 @@
           "name": "Foreground"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#F6F6F6",
-          "name": "Background Alt"
+          "slug": "ti-accent",
+          "color": "#F5AB1A",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
@@ -26,14 +26,14 @@
           "name": "Background Dark"
         },
         {
+          "slug": "ti-bg-alt",
+          "color": "#F6F6F6",
+          "name": "Background Alt"
+        },
+        {
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#F5AB1A",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s2-majorelle-blue.json
+++ b/styles/s2-majorelle-blue.json
@@ -16,9 +16,9 @@
           "name": "Foreground"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#EEEBF5",
-          "name": "Background Alt"
+          "slug": "ti-accent",
+          "color": "#5E33D9",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
@@ -26,14 +26,14 @@
           "name": "Background Dark"
         },
         {
+          "slug": "ti-bg-alt",
+          "color": "#EEEBF5",
+          "name": "Background Alt"
+        },
+        {
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#5E33D9",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s3-zomp.json
+++ b/styles/s3-zomp.json
@@ -16,9 +16,9 @@
           "name": "Foreground"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#FFFFFF",
-          "name": "Background Alt"
+          "slug": "ti-accent",
+          "color": "#429C91",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
@@ -26,14 +26,14 @@
           "name": "Background Dark"
         },
         {
+          "slug": "ti-bg-alt",
+          "color": "#FFFFFF",
+          "name": "Background Alt"
+        },
+        {
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#429C91",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s4-dark-pastel-red.json
+++ b/styles/s4-dark-pastel-red.json
@@ -16,9 +16,9 @@
           "name": "Foreground"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#FFFFFF",
-          "name": "Background Alt"
+          "slug": "ti-accent",
+          "color": "#C6461E",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
@@ -26,14 +26,14 @@
           "name": "Background Dark"
         },
         {
+          "slug": "ti-bg-alt",
+          "color": "#FFFFFF",
+          "name": "Background Alt"
+        },
+        {
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#C6461E",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s5-aztec-gold.json
+++ b/styles/s5-aztec-gold.json
@@ -16,6 +16,11 @@
           "name": "Foreground"
         },
         {
+          "slug": "ti-accent",
+          "color": "#BF985C",
+          "name": "Accent"
+        },
+        {
           "slug": "ti-bg-alt",
           "color": "#1F1F1F",
           "name": "Background Alt"
@@ -29,11 +34,6 @@
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#BF985C",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s6-vivid-red-tangelo.json
+++ b/styles/s6-vivid-red-tangelo.json
@@ -16,6 +16,11 @@
           "name": "Foreground"
         },
         {
+          "slug": "ti-accent",
+          "color": "#DF6018",
+          "name": "Accent"
+        },
+        {
           "slug": "ti-bg-alt",
           "color": "#0E313E",
           "name": "Background Alt"
@@ -29,11 +34,6 @@
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#DF6018",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s7-greenlight.json
+++ b/styles/s7-greenlight.json
@@ -16,9 +16,9 @@
           "name": "Foreground"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#F6F3EE",
-          "name": "Background Alt"
+          "slug": "ti-accent",
+          "color": "#518459",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
@@ -26,14 +26,14 @@
           "name": "Background Dark"
         },
         {
+          "slug": "ti-bg-alt",
+          "color": "#F6F3EE",
+          "name": "Background Alt"
+        },
+        {
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#518459",
-          "name": "Accent"
         }
       ]
     }

--- a/theme.json
+++ b/theme.json
@@ -49,9 +49,9 @@
           "name": "Foreground"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "var(--nv-light-bg, #f7f7f3)",
-          "name": "Background Alt"
+          "slug": "ti-accent",
+          "color": "var(--nv-primary-accent, #325ce8)",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
@@ -59,14 +59,14 @@
           "name": "Background Dark"
         },
         {
+          "slug": "ti-bg-alt",
+          "color": "var(--nv-light-bg, #f7f7f3)",
+          "name": "Background Alt"
+        },
+        {
           "slug": "ti-fg-alt",
           "color": "var(--nv-text-dark-bg, #FBFBFB)",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "var(--nv-primary-accent, #325ce8)",
-          "name": "Accent"
         }
       ],
       "link": true,


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
I have changed the order of the colors to better represent the available colors inside the style preview.
Check the screenshot section to compare the Previous Preview with the new one.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots 
<!-- if applicable -->
<details open>
<summary>New Style Preview</summary>

![image](https://github.com/Codeinwp/neve-fse/assets/23024731/fce70232-7e9a-4b59-8a4c-b4cf04100cf7)
</details>

<details>
<summary>Previous Style Preview</summary>

![image](https://github.com/Codeinwp/neve-fse/assets/23024731/07e157eb-429a-4f78-abdb-842ddbf039c4)
</details>

<details>
<summary>The Style tab - Pic 1</summary>

![image](https://github.com/Codeinwp/neve-fse/assets/23024731/298e0c30-f3b8-4e44-9924-c9facf99917e)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On an instance with Neve FSE
2. Check Go to **Appearance** > **Editor** > **Styles** (see. Pic 1),  **Browse styles**
3. Check the Style Preview

<!-- Issues that this pull request closes. -->
Closes #49.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->