### PR TITLE
Changes the color styles of the sections on the homepage + Adds new Styles

### DIFF
--- a/inc/patterns/layout/columns-image-and-text.php
+++ b/inc/patterns/layout/columns-image-and-text.php
@@ -21,8 +21,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Columns', 'content', 'image', 'text' ),
 	'content'    => '
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:64px;padding-bottom:64px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"ti-bg-alt","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-ti-bg-alt-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:64px;padding-bottom:64px">
     <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
     <div class="wp-block-columns alignwide">
         <!-- wp:column -->

--- a/inc/patterns/layout/columns-text-image.php
+++ b/inc/patterns/layout/columns-text-image.php
@@ -21,8 +21,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Columns', 'content', 'text', 'image' ),
 	'content'    => '
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"ti-bg-alt","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-ti-bg-alt-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:64px;padding-bottom:64px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"ti-bg","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-ti-bg-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:64px;padding-bottom:64px">
     <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
     <div class="wp-block-columns alignwide">
         <!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"}}}} -->

--- a/inc/patterns/layout/columns-with-icons.php
+++ b/inc/patterns/layout/columns-with-icons.php
@@ -23,8 +23,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Columns', 'icons', 'features' ),
 	'content'    => '
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px","right":"24px","left":"24px"},"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"ti-bg-alt","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-ti-bg-alt-background-color has-background" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-right:24px;padding-bottom:64px;padding-left:24px"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px","right":"24px","left":"24px"},"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"ti-bg","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-ti-bg-background-color has-background" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-right:24px;padding-bottom:64px;padding-left:24px"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"40px","left":"40px"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 <div class="wp-block-column" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"constrained","wideSize":"80px","justifyContent":"left","contentSize":"80px"}} -->
 <div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"style":{"border":{"radius":"100px"},"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}},"backgroundColor":"ti-accent","layout":{"type":"constrained","contentSize":"80px","justifyContent":"left"}} -->

--- a/inc/patterns/layout/page-cover-with-buttons.php
+++ b/inc/patterns/layout/page-cover-with-buttons.php
@@ -21,9 +21,9 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Hero', 'Page Hero', 'Cover' ),
 	'content'    => '
-<!-- wp:cover {"url":"' . esc_url( $cover_image ) . '","dimRatio":0,"overlayColor":"ti-bg-inv","minHeight":600,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"}}}} -->
+<!-- wp:cover {"url":"' . esc_url( $cover_image ) . '","dimRatio":0,"minHeight":600,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"}},"color":{"duotone":"var:preset|duotone|default-neve-overlay"}}} -->
 <div class="wp-block-cover alignfull is-light" style="padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:600px">
-    <span aria-hidden="true" class="wp-block-cover__background has-ti-bg-inv-background-color has-background-dim-0 has-background-dim"></span>
+    <span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
     <img class="wp-block-cover__image-background" alt="" src="' . esc_url( $cover_image ) . '" data-object-fit="cover"/>
     <div class="wp-block-cover__inner-container">
         <!-- wp:group {"layout":{"type":"constrained"}} -->

--- a/styles/s1-crayola.json
+++ b/styles/s1-crayola.json
@@ -50,28 +50,6 @@
   },
   "styles": {
     "elements": {
-      "button": {
-				"border": {
-					"radius": "0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--ti-accent)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "15px",
-						"right": "30px",
-						"bottom": "15px",
-						"left": "30px"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontWeight": "600",
-					"textTransform": "uppercase",
-					"letterSpacing": "0.01em"
-				}
-			},
       "heading": {
         "typography": {
           "fontFamily": "var(--wp--preset--font-family--inter)"

--- a/styles/s1-crayola.json
+++ b/styles/s1-crayola.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#F5AB1A",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s10-blaze-orange.json
+++ b/styles/s10-blaze-orange.json
@@ -7,7 +7,7 @@
       "duotone": [
 				{
 					"colors": [
-						"#007afc",
+						"#FF6602",
 						"#FFFFFF"
 					],
 					"slug": "default-neve-overlay",
@@ -17,17 +17,17 @@
       "palette": [
         {
           "slug": "ti-bg",
-          "color": "#0e1012",
+          "color": "#FFFFFF",
           "name": "Background"
         },
         {
           "slug": "ti-fg",
-          "color": "#f5f5f7",
+          "color": "#202020",
           "name": "Foreground"
         },
         {
           "slug": "ti-accent",
-          "color": "#007afc",
+          "color": "#FF6602",
           "name": "Accent"
         },
         {
@@ -37,12 +37,12 @@
         },
         {
           "slug": "ti-bg-alt",
-          "color": "#161A1D",
+          "color": "#F6F6F6",
           "name": "Background Alt"
         },
         {
           "slug": "ti-fg-alt",
-          "color": "#FFFFFA",
+          "color": "#EEEFE9",
           "name": "Foreground Alt"
         }
       ]

--- a/styles/s10-blaze-orange.json
+++ b/styles/s10-blaze-orange.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "title": "Hippie Green",
+  "title": "Blaze Orange",
   "version": 2,
   "settings": {
     "color": {

--- a/styles/s10-blaze-orange.json
+++ b/styles/s10-blaze-orange.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "title": "Crayola",
+  "title": "Hippie Green",
   "version": 2,
   "settings": {
     "color": {
       "duotone": [
 				{
 					"colors": [
-						"#F5AB1A",
+						"#007afc",
 						"#FFFFFF"
 					],
 					"slug": "default-neve-overlay",
@@ -17,27 +17,27 @@
       "palette": [
         {
           "slug": "ti-bg",
-          "color": "#FFFFFF",
+          "color": "#0e1012",
           "name": "Background"
         },
         {
           "slug": "ti-fg",
-          "color": "#1F2023",
+          "color": "#f5f5f7",
           "name": "Foreground"
         },
         {
           "slug": "ti-accent",
-          "color": "#F5AB1A",
+          "color": "#007afc",
           "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
-          "color": "#14171C",
+          "color": "#000000",
           "name": "Background Dark"
         },
         {
           "slug": "ti-bg-alt",
-          "color": "#F6F6F6",
+          "color": "#161A1D",
           "name": "Background Alt"
         },
         {

--- a/styles/s10-blaze-orange.json
+++ b/styles/s10-blaze-orange.json
@@ -74,27 +74,27 @@
 			},
       "heading": {
         "typography": {
-          "fontFamily": "var(--wp--preset--font-family--inter)"
+          "fontFamily": "var(--wp--preset--font-family--open-sans)"
         }
       },
       "h1": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "900"
         }
       },
       "h2": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "900"
         }
       },
       "h3": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "900"
         }
       },
       "h4": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "900"
         }
       },
       "h5": {
@@ -109,7 +109,7 @@
       }
     },
     "typography": {
-      "fontFamily": "var(--wp--preset--font-family--inter)"
+      "fontFamily": "var(--wp--preset--font-family--montserrat)"
     }
   }
 }

--- a/styles/s11-monochrome-blue.json
+++ b/styles/s11-monochrome-blue.json
@@ -52,7 +52,7 @@
     "elements": {
       "button": {
 				"border": {
-					"radius": "0"
+					"radius": "50"
 				},
 				"color": {
 					"background": "var(--wp--preset--color--ti-accent)"
@@ -74,7 +74,7 @@
 			},
       "heading": {
         "typography": {
-          "fontFamily": "var(--wp--preset--font-family--inter)"
+          "fontFamily": "var(--wp--preset--font-family--source-sans-pro)"
         }
       },
       "h1": {

--- a/styles/s11-monochrome-blue.json
+++ b/styles/s11-monochrome-blue.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "title": "Crayola",
+  "title": "Mono Blue",
   "version": 2,
   "settings": {
     "color": {
       "duotone": [
 				{
 					"colors": [
-						"#F5AB1A",
+						"#2242A0",
 						"#FFFFFF"
 					],
 					"slug": "default-neve-overlay",
@@ -17,32 +17,32 @@
       "palette": [
         {
           "slug": "ti-bg",
-          "color": "#FFFFFF",
+          "color": "#E2E8F9",
           "name": "Background"
         },
         {
           "slug": "ti-fg",
-          "color": "#1F2023",
+          "color": "#313132",
           "name": "Foreground"
         },
         {
           "slug": "ti-accent",
-          "color": "#F5AB1A",
+          "color": "#2242A0",
           "name": "Accent"
         },
         {
           "slug": "ti-bg-inv",
-          "color": "#14171C",
+          "color": "#182F71",
           "name": "Background Dark"
         },
         {
           "slug": "ti-bg-alt",
-          "color": "#F6F6F6",
+          "color": "#EEF2FC",
           "name": "Background Alt"
         },
         {
           "slug": "ti-fg-alt",
-          "color": "#FFFFFA",
+          "color": "#EEF2FC",
           "name": "Foreground Alt"
         }
       ]

--- a/styles/s11-monochrome-blue.json
+++ b/styles/s11-monochrome-blue.json
@@ -42,7 +42,7 @@
         },
         {
           "slug": "ti-fg-alt",
-          "color": "#EEF2FC",
+          "color": "#FFFFFA",
           "name": "Foreground Alt"
         }
       ]

--- a/styles/s2-majorelle-blue.json
+++ b/styles/s2-majorelle-blue.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#5E33D9",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s3-zomp.json
+++ b/styles/s3-zomp.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#F5AB1A",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s3-zomp.json
+++ b/styles/s3-zomp.json
@@ -7,7 +7,7 @@
       "duotone": [
 				{
 					"colors": [
-						"#F5AB1A",
+						"#429C91",
 						"#FFFFFF"
 					],
 					"slug": "default-neve-overlay",

--- a/styles/s4-dark-pastel-red.json
+++ b/styles/s4-dark-pastel-red.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#C6461E",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s5-aztec-gold.json
+++ b/styles/s5-aztec-gold.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#BF985C",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s6-vivid-red-tangelo.json
+++ b/styles/s6-vivid-red-tangelo.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#DF6018",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s7-greenlight.json
+++ b/styles/s7-greenlight.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#518459",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/styles/s8-tiber.json
+++ b/styles/s8-tiber.json
@@ -4,6 +4,16 @@
   "version": 2,
   "settings": {
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#007afc",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",
@@ -14,6 +24,11 @@
           "slug": "ti-fg",
           "color": "#f5f5f7",
           "name": "Foreground"
+        },
+        {
+          "slug": "ti-accent",
+          "color": "#007afc",
+          "name": "Accent"
         },
         {
           "slug": "ti-bg-alt",
@@ -29,11 +44,6 @@
           "slug": "ti-fg-alt",
           "color": "#FFFFFA",
           "name": "Foreground Alt"
-        },
-        {
-          "slug": "ti-accent",
-          "color": "#007afc",
-          "name": "Accent"
         }
       ]
     }

--- a/styles/s8-tiber.json
+++ b/styles/s8-tiber.json
@@ -81,6 +81,14 @@
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"
+				},
+        "spacing": {
+					"padding": {
+						"bottom": "10px",
+						"left": "20px",
+						"right": "20px",
+						"top": "10px"
+					}
 				}
 			}
     },

--- a/styles/s8-tiber.json
+++ b/styles/s8-tiber.json
@@ -57,32 +57,32 @@
       },
       "h1": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "700"
         }
       },
       "h2": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "700"
         }
       },
       "h3": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "700"
         }
       },
       "h4": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "700"
         }
       },
       "h5": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "700"
         }
       },
       "h6": {
         "typography": {
-          "fontWeight": "600"
+          "fontWeight": "700"
         }
       },
       "button": {
@@ -94,10 +94,10 @@
 				},
         "spacing": {
 					"padding": {
-						"bottom": "10px",
-						"left": "20px",
-						"right": "20px",
-						"top": "10px"
+						"bottom": "16px",
+						"left": "32px",
+						"right": "32px",
+						"top": "16px"
 					}
 				}
 			}

--- a/styles/s8-tiber.json
+++ b/styles/s8-tiber.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "title": "Tiber",
+  "version": 2,
+  "settings": {
+    "color": {
+      "palette": [
+        {
+          "slug": "ti-bg",
+          "color": "#0e1012",
+          "name": "Background"
+        },
+        {
+          "slug": "ti-fg",
+          "color": "#f5f5f7",
+          "name": "Foreground"
+        },
+        {
+          "slug": "ti-bg-alt",
+          "color": "#161A1D",
+          "name": "Background Alt"
+        },
+        {
+          "slug": "ti-bg-inv",
+          "color": "#000000",
+          "name": "Background Dark"
+        },
+        {
+          "slug": "ti-fg-alt",
+          "color": "#FFFFFA",
+          "name": "Foreground Alt"
+        },
+        {
+          "slug": "ti-accent",
+          "color": "#007afc",
+          "name": "Accent"
+        }
+      ]
+    }
+  },
+  "styles": {
+    "elements": {
+      "heading": {
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--albert-sans)"
+        }
+      },
+      "h1": {
+        "typography": {
+          "fontWeight": "600"
+        }
+      },
+      "h2": {
+        "typography": {
+          "fontWeight": "600"
+        }
+      },
+      "h3": {
+        "typography": {
+          "fontWeight": "600"
+        }
+      },
+      "h4": {
+        "typography": {
+          "fontWeight": "600"
+        }
+      },
+      "h5": {
+        "typography": {
+          "fontWeight": "600"
+        }
+      },
+      "h6": {
+        "typography": {
+          "fontWeight": "600"
+        }
+      },
+      "button": {
+				"border": {
+					"radius": "50px"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			}
+    },
+    "typography": {
+      "fontFamily": "var(--wp--preset--font-family--albert-sans)"
+    }
+  }
+}

--- a/styles/s9-hippie-green.json
+++ b/styles/s9-hippie-green.json
@@ -52,7 +52,7 @@
     "elements": {
       "heading": {
         "typography": {
-          "fontFamily": "var(--wp--preset--font-family--albert-sans)"
+          "fontFamily": "var(--wp--preset--font-family--playfair-display)"
         }
       },
       "h1": {
@@ -87,23 +87,23 @@
       },
       "button": {
 				"border": {
-					"radius": "50px"
+					"radius": "0px"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				},
         "spacing": {
 					"padding": {
-						"bottom": "10px",
-						"left": "20px",
-						"right": "20px",
-						"top": "10px"
+						"bottom": "15px",
+						"left": "30px",
+						"right": "30px",
+						"top": "15px"
 					}
 				}
 			}
     },
     "typography": {
-      "fontFamily": "var(--wp--preset--font-family--albert-sans)"
+      "fontFamily": "var(--wp--preset--font-family--open-sans)"
     }
   }
 }

--- a/styles/s9-hippie-green.json
+++ b/styles/s9-hippie-green.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "title": "Tiber",
+  "title": "Hippie Green",
   "version": 2,
   "settings": {
     "color": {

--- a/styles/s9-hippie-green.json
+++ b/styles/s9-hippie-green.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
-  "title": "Crayola",
+  "title": "Tiber",
   "version": 2,
   "settings": {
     "color": {
       "duotone": [
 				{
 					"colors": [
-						"#F5AB1A",
+						"#007afc",
 						"#FFFFFF"
 					],
 					"slug": "default-neve-overlay",
@@ -17,28 +17,28 @@
       "palette": [
         {
           "slug": "ti-bg",
-          "color": "#FFFFFF",
+          "color": "#0e1012",
           "name": "Background"
         },
         {
           "slug": "ti-fg",
-          "color": "#1F2023",
+          "color": "#f5f5f7",
           "name": "Foreground"
         },
         {
           "slug": "ti-accent",
-          "color": "#F5AB1A",
+          "color": "#007afc",
           "name": "Accent"
         },
         {
-          "slug": "ti-bg-inv",
-          "color": "#14171C",
-          "name": "Background Dark"
+          "slug": "ti-bg-alt",
+          "color": "#161A1D",
+          "name": "Background Alt"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#F6F6F6",
-          "name": "Background Alt"
+          "slug": "ti-bg-inv",
+          "color": "#000000",
+          "name": "Background Dark"
         },
         {
           "slug": "ti-fg-alt",
@@ -50,31 +50,9 @@
   },
   "styles": {
     "elements": {
-      "button": {
-				"border": {
-					"radius": "0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--ti-accent)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "15px",
-						"right": "30px",
-						"bottom": "15px",
-						"left": "30px"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontWeight": "600",
-					"textTransform": "uppercase",
-					"letterSpacing": "0.01em"
-				}
-			},
       "heading": {
         "typography": {
-          "fontFamily": "var(--wp--preset--font-family--inter)"
+          "fontFamily": "var(--wp--preset--font-family--albert-sans)"
         }
       },
       "h1": {
@@ -106,10 +84,26 @@
         "typography": {
           "fontWeight": "600"
         }
-      }
+      },
+      "button": {
+				"border": {
+					"radius": "50px"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				},
+        "spacing": {
+					"padding": {
+						"bottom": "10px",
+						"left": "20px",
+						"right": "20px",
+						"top": "10px"
+					}
+				}
+			}
     },
     "typography": {
-      "fontFamily": "var(--wp--preset--font-family--inter)"
+      "fontFamily": "var(--wp--preset--font-family--albert-sans)"
     }
   }
 }

--- a/styles/s9-hippie-green.json
+++ b/styles/s9-hippie-green.json
@@ -7,7 +7,7 @@
       "duotone": [
 				{
 					"colors": [
-						"#007afc",
+						"#497B4E",
 						"#FFFFFF"
 					],
 					"slug": "default-neve-overlay",

--- a/styles/s9-hippie-green.json
+++ b/styles/s9-hippie-green.json
@@ -17,7 +17,7 @@
       "palette": [
         {
           "slug": "ti-bg",
-          "color": "#0e1012",
+          "color": "#1A261B",
           "name": "Background"
         },
         {
@@ -27,18 +27,18 @@
         },
         {
           "slug": "ti-accent",
-          "color": "#007afc",
+          "color": "#497B4E",
           "name": "Accent"
         },
         {
-          "slug": "ti-bg-alt",
-          "color": "#161A1D",
-          "name": "Background Alt"
+          "slug": "ti-bg-inv",
+          "color": "#080C09",
+          "name": "Background Dark"
         },
         {
-          "slug": "ti-bg-inv",
-          "color": "#000000",
-          "name": "Background Dark"
+          "slug": "ti-bg-alt",
+          "color": "#394E3C",
+          "name": "Background Alt"
         },
         {
           "slug": "ti-fg-alt",

--- a/theme.json
+++ b/theme.json
@@ -428,6 +428,11 @@
           "text": "var(--wp--preset--color--ti-fg)"
         }
       },
+      "button": {
+				"border": {
+					"radius": "8px"
+				}
+			},
       "h1": {
         "typography": {
           "fontSize": "var(--neve-font-size-h1, var(--wp--preset--font-size--huge))",
@@ -473,38 +478,14 @@
     },
     "blocks": {
       "core/site-logo": {
-         "dimensions": {
-            "width": "48"
-         }
-      },
-      "core/button": {
-        "border": {
-          "radius": "var(--neve-button-border-radius, 5px)",
-          "width": "2px",
-          "style": "solid",
-          "color": "var(--wp--preset--color--ti-accent)"
-        },
-        "color": {
-          "background": "var(--wp--preset--color--ti-accent)",
-          "text": "var(--wp--preset--color--ti-fg-alt)"
-        },
-        "spacing": {
-          "padding": {
-            "bottom": "16px",
-            "left": "40px",
-            "right": "40px",
-            "top": "16px"
-          }
-        },
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--normal)",
-          "fontWeight": "600"
+        "dimensions": {
+          "width": "48"
         }
       },
       "core/latest-posts": {
         "typography": {
-            "fontSize": "var(--wp--preset--font-size--medium)",
-            "fontWeight": "600"
+          "fontSize": "var(--wp--preset--font-size--medium)",
+          "fontWeight": "600"
         }
       },
       "core/comment-content": {

--- a/theme.json
+++ b/theme.json
@@ -36,6 +36,16 @@
       }
     },
     "color": {
+      "duotone": [
+				{
+					"colors": [
+						"#325ce8",
+						"#FFFFFF"
+					],
+					"slug": "default-neve-overlay",
+					"name": "Default Neve overlay"
+				}
+			],
       "palette": [
         {
           "slug": "ti-bg",

--- a/theme.json
+++ b/theme.json
@@ -430,8 +430,27 @@
       },
       "button": {
 				"border": {
-					"radius": "8px"
-				}
+					"radius": "5px",
+          "width": "2px",
+          "style": "solid",
+          "color": "var(--wp--preset--color--ti-accent)"
+				},
+        "color": {
+          "background": "var(--wp--preset--color--ti-accent)",
+          "text": "var(--wp--preset--color--ti-fg-alt)"
+        },
+        "spacing": {
+          "padding": {
+            "bottom": "16px",
+            "left": "40px",
+            "right": "40px",
+            "top": "16px"
+          }
+        },
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--normal)",
+          "fontWeight": "600"
+        }
 			},
       "h1": {
         "typography": {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->
**Before**

<img width="1725" alt="Screenshot 2023-07-18 at 14 44 41" src="https://github.com/Codeinwp/neve-fse/assets/52494172/1f90633e-45d1-4512-a25b-074efef46abe">

___

**After**
<img width="1714" alt="Screenshot 2023-07-18 at 14 42 29" src="https://github.com/Codeinwp/neve-fse/assets/52494172/59f2cd97-deaf-4563-aca6-6b23b513b939">




### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install Neve FSE on a fresh instance
- Add the build
- see the new background colors for the 3 sections on the homepage (columns with icons, image and text, text and image)
- test the 4 new Styles: Tiber, Hippie green, Blaze orange, Monochrome blue
- test that Hero image has a Duotone filter, which should make the hero look better - even when the color is not matching blue

<!-- Issues that this pull request closes. -->
Closes #71 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->

This should fix the issue where in the WP repo, previewing colors will make the Nav Bar look different compared to the Icons section (examples below where it's visible that things can be improved):

<details><summary>Images</summary>

<img width="1022" alt="Screenshot 2023-07-18 at 14 46 38" src="https://github.com/Codeinwp/neve-fse/assets/52494172/36ef0ac3-ffa9-4758-b2b2-5ed756d5bf0d">

___

<img width="1083" alt="Screenshot 2023-07-18 at 14 47 18" src="https://github.com/Codeinwp/neve-fse/assets/52494172/717192cd-b006-4572-9635-aadd8ec1f40b">

</details>


Closes #71 

___

@JohnPixle , when you have some time, please let me know if this is ok - and I'll pass it to testing. 🙇 
After this I'll create also a new PR with more color styles and small updates on the current ones. 