### PR TITLE
Changes the padding on Mobile for buttons

### DIFF
--- a/assets/css/src/common/_generic.scss
+++ b/assets/css/src/common/_generic.scss
@@ -1,3 +1,5 @@
+@custom-media --mobile (max-width: 481px);
+
 * {
 	box-sizing: border-box;
 }
@@ -76,4 +78,15 @@ body .wp-block-button.is-style-outline > .wp-block-button__link,
 body .wp-block-button .wp-block-button__link.is-style-outline {
 	border: 2px solid;
 	padding: 16px 40px;
+
+	@media (--mobile) {
+		padding: 16px 20px;
+	}
+}
+
+body .wp-block-button .wp-block-button__link {
+
+	@media (--mobile) {
+		padding: 16px 20px;
+	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Changes the padding for Primary and Secondary buttons on Mobile, using a Media Query

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->

**BEFORE**
![Screenshot 2023-07-20 at 11 43 13](https://github.com/Codeinwp/neve-fse/assets/52494172/3d9454fd-26a5-4f44-97f5-ccf2ad92c793)


**AFTER**
![Screenshot 2023-07-20 at 12 15 52](https://github.com/Codeinwp/neve-fse/assets/52494172/bc796551-7cd7-4dcd-ab4b-dcf3ff626df4)


 

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Install the new build on a fresh instance
2. Test on Mobile (small) that the buttons have smaller padding (16px 20px), and are not stacking anymore.

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->
#55 