### PR TITLE
fix: solve douplicate title tag #53

### DIFF
--- a/inc/Core.php
+++ b/inc/Core.php
@@ -70,7 +70,6 @@ class Core {
 		add_theme_support( 'starter-content', $starter_content->get() );
 		add_theme_support( 'wp-block-styles' );
 		add_theme_support( 'automatic-feed-links' );
-		add_theme_support( 'title-tag' );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'editor-styles' );
 		add_theme_support(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Removed support for title tag to improve compatibility with RankMath

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots 
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Install and activate Neve FSE
2. Install and activate RankMath
3. Visit the website you are testing on, check the page source, and search for the `<title/>` tag, it should display only once within the `<head/>` tag.


<!-- Issues that this pull request closes. -->
Closes #53.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->