### PR TITLE
Fix growing height of patterns when browsing styles

### DIFF
--- a/inc/patterns/layout/cta-dark.php
+++ b/inc/patterns/layout/cta-dark.php
@@ -19,8 +19,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'call to action', 'CTA', 'inverted', 'dark', 'centered', 'cover' ),
 	'content'    => '
-<!-- wp:cover {"overlayColor":"ti-bg-inv","minHeight":50,"minHeightUnit":"vh","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"},"margin":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-cover alignfull" style="margin-top:0;margin-bottom:0;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:50vh"><span aria-hidden="true" class="wp-block-cover__background has-ti-bg-inv-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"textColor":"ti-fg-alt","layout":{"type":"constrained"}} -->
+<!-- wp:cover {"overlayColor":"ti-bg-inv","minHeight":500,"minHeightUnit":"px","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-cover alignfull" style="margin-top:0;margin-bottom:0;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:500px"><span aria-hidden="true" class="wp-block-cover__background has-ti-bg-inv-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"textColor":"ti-fg-alt","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-ti-fg-alt-color has-text-color"><!-- wp:heading {"textAlign":"center","align":"wide","fontSize":"huge"} -->
 <h2 class="wp-block-heading alignwide has-text-align-center has-huge-font-size">Let’s work together on your<br>next project</h2>
 <!-- /wp:heading -->

--- a/inc/patterns/layout/page-cover-bg-image.php
+++ b/inc/patterns/layout/page-cover-bg-image.php
@@ -21,8 +21,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'call to action', 'page cover', 'inverted', 'dark' ),
 	'content'    => '
-<!-- wp:cover {"url":"' . esc_url( $cover_image ) . '","dimRatio":50,"overlayColor":"ti-bg-inv","minHeight":50,"minHeightUnit":"vh","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"},"margin":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="margin-top:0;margin-bottom:0;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:50vh">
+<!-- wp:cover {"url":"' . esc_url( $cover_image ) . '","dimRatio":50,"overlayColor":"ti-bg-inv","minHeight":500,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="margin-top:0;margin-bottom:0;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:500px">
     <span aria-hidden="true" class="wp-block-cover__background has-ti-bg-inv-background-color has-background-dim"></span>
     <img class="wp-block-cover__image-background" alt="" src="' . esc_url( $cover_image ) . '" data-object-fit="cover"/>
     <div class="wp-block-cover__inner-container">

--- a/inc/patterns/layout/page-cover-with-buttons.php
+++ b/inc/patterns/layout/page-cover-with-buttons.php
@@ -21,8 +21,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Hero', 'Page Hero', 'Cover' ),
 	'content'    => '
-<!-- wp:cover {"url":"' . esc_url( $cover_image ) . '","dimRatio":0,"overlayColor":"ti-bg-inv","minHeight":60,"minHeightUnit":"vh","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:60vh">
+<!-- wp:cover {"url":"' . esc_url( $cover_image ) . '","dimRatio":0,"overlayColor":"ti-bg-inv","minHeight":600,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px;min-height:600px">
     <span aria-hidden="true" class="wp-block-cover__background has-ti-bg-inv-background-color has-background-dim-0 has-background-dim"></span>
     <img class="wp-block-cover__image-background" alt="" src="' . esc_url( $cover_image ) . '" data-object-fit="cover"/>
     <div class="wp-block-cover__inner-container">


### PR DESCRIPTION
### Summary
Replaced the 50 / 60 vh in patterns with 500 / 600 px

### Will affect the visual aspect of the product
NO

### Screenshots
https://github.com/Codeinwp/neve-fse/assets/52494172/09cabbc5-95db-4cb8-b093-b724f5c346f7

### Test instructions
- Install Neve FSE 1.0.5
- Open Editor on the Homepage
- Open the Style Tab and switch styles
( or follow the video )

<!-- Issues that this pull request closes. -->
Closes #73.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->