### PR TITLE
fix: unwanted padding inside the page editor [#54]

### DIFF
--- a/assets/css/src/common/_generic.scss
+++ b/assets/css/src/common/_generic.scss
@@ -42,18 +42,6 @@ footer {
  * https://github.com/WordPress/gutenberg/issues/35884
  */
 
-.wp-site-blocks,
-body > .is-root-container,
-.edit-post-visual-editor__post-title-wrapper,
-.wp-block-group.alignfull,
-.wp-block-group.has-background,
-.wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group,
-.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
-	padding-left: var(--wp--custom--spacing--outer);
-	padding-right: var(--wp--custom--spacing--outer);
-}
-
 .wp-site-blocks .alignfull,
 .wp-site-blocks > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-cover,

--- a/theme.json
+++ b/theme.json
@@ -10,8 +10,7 @@
           "horizontal": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 2.222vw, calc( 2 * var( --wp--custom--spacing--baseline ) ) )",
           "vertical": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )"
         },
-        "gutter": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )",
-        "outer": "var( --wp--custom--spacing--gutter )"
+        "gutter": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )"
       },
       "typography": {
         "fontSmoothing": {


### PR DESCRIPTION
### Summary
- Removed unnecessary code from CSS.
- Removed unnecessary property from theme.json

####Context
Bogdan started from Fork's style, we have the same issue there. After digging a while, here's what I've found:

The style was added because in ( not that ) older WP versions ( eg. WP 6.1 ) we had this issue: https://vertis.d.pr/v/VLFBl1. After digging some more,  I found out that removing this line here https://github.com/Codeinwp/neve-fse/blob/main/theme.json#L14 fixes both the current issue that we have now, and the fix even works on WP 6.1, allowing us to also remove that padding style. There's no need to change the templates.

### Will affect the visual aspect of the product
NO


### Test instructions
- Install this build of Neve FSE and try to edit the front page or any other page. The padding inside the editor shouldn't be there anymore
- Switch to WP 6.1 and make sure this issue: https://vertis.d.pr/v/VLFBl1 is not happening anymore

<!-- Issues that this pull request closes. -->
Closes #54.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->