### PR TITLE
Adds accent color on testimonials section homepage + changes

### DIFF
--- a/inc/patterns/layout/columns-testimonials.php
+++ b/inc/patterns/layout/columns-testimonials.php
@@ -23,8 +23,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Columns', 'testimonial', 'client', 'review' ),
 	'content'    => '
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"40px"}},"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-bottom:64px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"40px"}},"backgroundColor":"ti-accent","textColor":"ti-fg-alt","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-ti-fg-alt-color has-ti-accent-background-color has-text-color has-background" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-bottom:64px">
     <!-- wp:group {"align":"wide"} -->
     <div class="wp-block-group alignwide">
         <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"24px","left":"24px"}}}} -->
@@ -44,7 +44,7 @@ return array(
                     <!-- /wp:paragraph -->
 
                     <!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-                    <p class="has-text-align-left has-small-font-size"><strong>JOHN DOE</strong></p>
+                    <p class="has-text-align-left has-small-font-size"><strong>JANE DOE</strong></p>
                     <!-- /wp:paragraph -->
                 </div>
                 <!-- /wp:group -->
@@ -66,7 +66,7 @@ return array(
                     <!-- /wp:paragraph -->
 
                     <!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-                    <p class="has-text-align-left has-small-font-size"><strong>JANE DOE</strong></p>
+                    <p class="has-text-align-left has-small-font-size"><strong>JOHN DOE</strong></p>
                     <!-- /wp:paragraph -->
                 </div>
                 <!-- /wp:group -->
@@ -88,7 +88,7 @@ return array(
                     <!-- /wp:paragraph -->
 
                     <!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-                    <p class="has-text-align-left has-small-font-size"><strong>GEORGE DOE</strong></p>
+                    <p class="has-text-align-left has-small-font-size"><strong>MARIA DOE</strong></p>
                     <!-- /wp:paragraph -->
                 </div>
                 <!-- /wp:group -->

--- a/inc/patterns/layout/portfolio-columns.php
+++ b/inc/patterns/layout/portfolio-columns.php
@@ -22,8 +22,8 @@ return array(
 	'categories' => array( 'neve-fse' ),
 	'keywords'   => array( 'Columns', 'portfolio', 'cover' ),
 	'content'    => '
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"ti-fg-alt","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-ti-fg-alt-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:64px;padding-bottom:64px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"64px"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"ti-bg","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-ti-bg-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:64px;padding-bottom:64px">
     <!-- wp:heading {"textAlign":"left","align":"wide"} -->
     <h2 class="wp-block-heading alignwide has-text-align-left">Featured Work</h2>
     <!-- /wp:heading -->


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
- Adds the accent color as background color to the Penultimate section on the homepage
- adds site bg color to the Featured Work section. Currently Foreground color is used there

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->

### Before

https://github.com/Codeinwp/neve-fse/assets/52494172/ae602268-a752-4a88-8ba5-3114d4edfb68





### After

https://github.com/Codeinwp/neve-fse/assets/52494172/f9d16318-79af-4394-a780-f53740a6114b




### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install the new build
2. Test if the Penultimate section (testimonials) uses the Accent color as background color
3. and the section above that (Featured Work) should used the Site Background color - not foreground color
4. Make sure it works ok on light and dark palettes  

<!-- Issues that this pull request closes. -->
Closes #76
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->