### PR TITLE
Adds secondary color and their values for each style

### DIFF
--- a/styles/s1-crayola.json
+++ b/styles/s1-crayola.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #E1980A)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-inv",
           "color": "#14171C",
           "name": "Background Dark"

--- a/styles/s1-crayola.json
+++ b/styles/s1-crayola.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #E1980A)",
+          "color": "#E1980A",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s2-majorelle-blue.json
+++ b/styles/s2-majorelle-blue.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #4F25C6)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-inv",
           "color": "#261E3C",
           "name": "Background Dark"

--- a/styles/s2-majorelle-blue.json
+++ b/styles/s2-majorelle-blue.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #4F25C6)",
+          "color": "#4F25C6",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s3-zomp.json
+++ b/styles/s3-zomp.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #3A8A80)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-inv",
           "color": "#1E2827",
           "name": "Background Dark"

--- a/styles/s3-zomp.json
+++ b/styles/s3-zomp.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #3A8A80)",
+          "color": "#3A8A80",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s4-dark-pastel-red.json
+++ b/styles/s4-dark-pastel-red.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #A93C19)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-inv",
           "color": "#1D1A1A",
           "name": "Background Dark"

--- a/styles/s4-dark-pastel-red.json
+++ b/styles/s4-dark-pastel-red.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #A93C19)",
+          "color": "#A93C19",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s5-aztec-gold.json
+++ b/styles/s5-aztec-gold.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #AD8A54)",
+          "color": "#AD8A54",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s5-aztec-gold.json
+++ b/styles/s5-aztec-gold.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #AD8A54)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-alt",
           "color": "#1F1F1F",
           "name": "Background Alt"

--- a/styles/s6-vivid-red-tangelo.json
+++ b/styles/s6-vivid-red-tangelo.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #CC5816)",
+          "color": "#CC5816",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s6-vivid-red-tangelo.json
+++ b/styles/s6-vivid-red-tangelo.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #CC5816)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-alt",
           "color": "#0E313E",
           "name": "Background Alt"

--- a/styles/s7-greenlight.json
+++ b/styles/s7-greenlight.json
@@ -22,7 +22,7 @@
         },
         {
           "slug": "ti-accent-secondary",
-          "color": "var(--nv-secondary-accent, #46734D)",
+          "color": "#46734D",
           "name": "Accent Secondary"
         },
         {

--- a/styles/s7-greenlight.json
+++ b/styles/s7-greenlight.json
@@ -21,6 +21,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #46734D)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-inv",
           "color": "#14171C",
           "name": "Background Dark"

--- a/theme.json
+++ b/theme.json
@@ -54,6 +54,11 @@
           "name": "Accent"
         },
         {
+          "slug": "ti-accent-secondary",
+          "color": "var(--nv-secondary-accent, #1B47DA)",
+          "name": "Accent Secondary"
+        },
+        {
           "slug": "ti-bg-inv",
           "color": "var(--nv-dark-bg, #1A1919)",
           "name": "Background Dark"


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Add the Secondary Accent color in the main theme.json file
and also added for each palette separately, the corresponding colors

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots 
<!-- if applicable -->
![image](https://github.com/Codeinwp/neve-fse/assets/52494172/835f823f-61b4-4524-a0fc-7eb729740651)



### Test instructions
<!-- Describe how this pull request can be tested. -->

- This changes are just in code. **We don't use the Secondary color anywhere, yet.**
- with this PR, the main palette should have a secondary color (in code). Same applies to all other color palettes.

<!-- Issues that this pull request closes. -->
Closes #92 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->