### PR TITLE
fix: pagination missing & limited to three pages

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -9,7 +9,7 @@
     <!-- /wp:group -->
 
     <!-- wp:group {"style":{"spacing":{"padding":{"top":"64px","bottom":"64px","right":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"0px"}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-right:0px;padding-bottom:64px;padding-left:0px"><!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":"3","offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
+    <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-right:0px;padding-bottom:64px;padding-left:0px"><!-- wp:query {"queryId":1,"query":{"perPage":3,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
         <div class="wp-block-query alignwide"><!-- wp:post-template -->
             <!-- wp:post-featured-image {"isLink":true} /-->
 
@@ -19,6 +19,17 @@
                 <!-- wp:post-title {"level":3,"isLink":true} /--></div>
             <!-- /wp:group -->
             <!-- /wp:post-template -->
+
+           <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"64px","bottom":"64px"}}}} -->
+           <div class="wp-block-group alignwide" style="margin-top:64px;margin-bottom:64px">
+               <!-- wp:query-pagination {"textColor":"ti-fg","layout":{"type":"flex","justifyContent":"space-between"}} -->
+               <!-- wp:query-pagination-previous /-->
+
+                <!-- wp:query-pagination-numbers /-->
+
+                <!-- wp:query-pagination-next /-->
+                <!-- /wp:query-pagination --></div>
+            <!-- /wp:group -->
 
             <!-- wp:query-no-results -->
             <!-- wp:paragraph {"align":"center","placeholder":"Add text or blocks that will display when a query returns no results.","backgroundColor":"ti-bg-inv","textColor":"ti-fg-alt"} -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,7 +9,7 @@
 
     <!-- wp:group {"style":{"spacing":{"padding":{"top":"64px","bottom":"64px","right":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"0px"}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:64px;padding-right:0px;padding-bottom:64px;padding-left:0px"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"40px","margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-        <div class="wp-block-group alignwide" style="margin-top:0px;margin-bottom:0px"><!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":"3","offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
+        <div class="wp-block-group alignwide" style="margin-top:0px;margin-bottom:0px"><!-- wp:query {"queryId":1,"query":{"perPage":3,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
             <div class="wp-block-query alignwide"><!-- wp:post-template -->
                 <!-- wp:post-featured-image {"isLink":true} /-->
 
@@ -17,6 +17,17 @@
 
                 <!-- wp:post-title {"level":3,"isLink":true} /-->
                 <!-- /wp:post-template -->
+
+                <!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"64px","bottom":"64px"}}}} -->
+                <div class="wp-block-group alignwide" style="margin-top:64px;margin-bottom:64px">
+                    <!-- wp:query-pagination {"textColor":"ti-fg","layout":{"type":"flex","justifyContent":"space-between"}} -->
+                    <!-- wp:query-pagination-previous /-->
+
+                    <!-- wp:query-pagination-numbers /-->
+
+                    <!-- wp:query-pagination-next /-->
+                    <!-- /wp:query-pagination --></div>
+                <!-- /wp:group -->
 
                 <!-- wp:query-no-results -->
                 <!-- wp:paragraph {"align":"center","placeholder":"Add text or blocks that will display when a query returns no results.","backgroundColor":"ti-bg-alt"} -->


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fixes the issue with Pagination missing in Archive & Search page, and being limited to only three pages.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots 
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a website with about 50 pages, and set posts per setting in Reading Settings to 5
- Confirm pagination appears in Archive and Search page, and you can see past 3 pages

<!-- Issues that this pull request closes. -->
Closes #105.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->