### PR TITLE
feat: add otter ref to Neve Fse

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.2'
           extensions: simplexml, mysql
           tools: phpunit-polyfills
       - name: Checkout source code
@@ -69,4 +69,4 @@ jobs:
       - name: Install composer
         run: composer install --prefer-dist --no-progress --no-suggest
       - name: Run phpunit
-        run: phpunit
+        run: composer run-script phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ assets/js/build
 languages/neve-fse.pot
 
 .DS_Store
+.phpunit.result.cache

--- a/assets/js/src/welcome-notice.js
+++ b/assets/js/src/welcome-notice.js
@@ -10,6 +10,7 @@ function handleWelcomeNotice( $ ) {
 		activationUrl,
 		ajaxUrl,
 		nonce,
+		otterRefNonce,
 		otterStatus,
 	} = neveFSEData;
 
@@ -30,6 +31,12 @@ function handleWelcomeNotice( $ ) {
 	const activateOtter = async () => {
 		installText.text( activating );
 		await activatePlugin( activationUrl );
+
+		await $.post( ajaxUrl, {
+			nonce: otterRefNonce,
+			action: 'neve_fse_set_otter_ref',
+		} );
+
 		installSpinner.removeClass( 'dashicons-update' );
 		installSpinner.addClass( 'dashicons-yes' );
 		installText.text( done );

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "format": "phpcbf --standard=phpcs.xml --report-summary --report-source -s  --runtime-set testVersion 7.0- ",
         "phpcs": "phpcs --standard=phpcs.xml -s  --runtime-set testVersion 7.0-",
         "lint": "composer run-script phpcs",
-        "phpcs-i": "phpcs -i"
+        "phpcs-i": "phpcs -i",
+        "phpunit": "phpunit"
     }
 }

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -443,11 +443,7 @@ class Admin {
 	 * @return void
 	 */
 	public function set_otter_ref() {
-		if ( empty( $_POST['nonce'] ) ) {
-			return;
-		}
-
-		if ( ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), 'neve-fse-set-otter-ref' ) ) {
+		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), 'neve-fse-set-otter-ref' ) ) {
 			return;
 		}
 

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -23,6 +23,13 @@ class Admin {
 	private $suspend_survey = true;
 
 	/**
+	 * Otter reference key.
+	 *
+	 * @var string
+	 */
+	const OTTER_REF = 'otter_reference_key';
+
+	/**
 	 * Admin constructor.
 	 */
 	public function __construct() {
@@ -59,6 +66,7 @@ class Admin {
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'add_fse_design_pack_notice' ) );
 		add_action( 'wp_ajax_neve_fse_dismiss_design_pack_notice', array( $this, 'remove_design_pack_notice' ) );
+		add_action( 'wp_ajax_neve_fse_set_otter_ref', array( $this, 'set_otter_ref' ) );
 	}
 
 	/**
@@ -78,11 +86,12 @@ class Admin {
 			true,
 			array(),
 			array(
-				'nonce'      => wp_create_nonce( 'neve-fse-dismiss-design-pack-notice' ),
-				'ajaxUrl'    => esc_url( admin_url( 'admin-ajax.php' ) ),
-				'ajaxAction' => 'neve_fse_dismiss_design_pack_notice',
-				'buttonLink' => tsdk_utmify( 'https://themeisle.com/plugins/fse-design-pack', 'editor', 'neve-fse' ),
-				'strings'    => array(
+				'nonce'         => wp_create_nonce( 'neve-fse-dismiss-design-pack-notice' ),
+				'otterRefNonce' => wp_create_nonce( 'neve-fse-set-otter-ref' ),
+				'ajaxUrl'       => esc_url( admin_url( 'admin-ajax.php' ) ),
+				'ajaxAction'    => 'neve_fse_dismiss_design_pack_notice',
+				'buttonLink'    => tsdk_utmify( 'https://themeisle.com/plugins/fse-design-pack', 'editor', 'neve-fse' ),
+				'strings'       => array(
 					'dismiss'    => __( 'Dismiss', 'neve-fse' ),
 					'recommends' => __( 'Neve FSE recommends', 'neve-fse' ),
 					'learnMore'  => __( 'Learn More', 'neve-fse' ),
@@ -426,6 +435,25 @@ class Admin {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Update Otter reference key.
+	 *
+	 * @return void
+	 */
+	public function set_otter_ref() {
+		if ( empty( $_POST['nonce'] ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), 'neve-fse-set-otter-ref' ) ) {
+			return;
+		}
+
+		update_option( self::OTTER_REF, 'neve-fse' );
+
+		wp_send_json_success();
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,11 @@
 define( 'NEVE_FSE_IGNORE_SOURCE_CHECK', true );
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( class_exists( '\Yoast\PHPUnitPolyfills\Autoload' ) === false ) {
+	require_once dirname( dirname( __FILE__ ) ) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+}
+
 if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This PR adds Otter ref to Neve FSE so it can be used for tracking traffic to Otter sales pages.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install Otter from the Neve FSE notice on Dashboard.
- After that confirm the upsells have neve-fse reference.

<!-- Issues that this pull request closes. -->
Closes #137.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->